### PR TITLE
Интерактивная установка trusttunnel_client, socks5 TrustTunnel

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -28,8 +28,8 @@ curl -fsSL "$REPO_URL/010-trusttunnel.sh" -o /opt/etc/ndm/wan.d/010-trusttunnel.
 chmod +x /opt/etc/ndm/wan.d/010-trusttunnel.sh
 
 ask_yes_no() {
-    echo "$1 (y/n)"
-    read answer
+    printf "%s (y/n) " "$1"
+    read answer < /dev/tty
     [ "$answer" = "y" ] || [ "$answer" = "Y" ]
 }
 


### PR DESCRIPTION
Добавил интерактивную установку trusttunnel_client, а также политику TrustTunnel и SOCKS5-подключение TrustTunnel.
Интерфейс создаётся через ndmc. Устанавливать ndmc не требуется — он присутствует в Entware по умолчанию.